### PR TITLE
Initial RBAC support: create and use Kubernetes service account for E…

### DIFF
--- a/pkg/controller/dormant_database.go
+++ b/pkg/controller/dormant_database.go
@@ -33,6 +33,19 @@ func (c *Controller) WaitUntilPaused(drmn *api.DormantDatabase) error {
 		return err
 	}
 
+	if err := c.waitUntilRBACStuffDeleted(db.ObjectMeta); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) waitUntilRBACStuffDeleted(meta metav1.ObjectMeta) error {
+	// Delete ServiceAccount
+	if err := core_util.WaitUntillServiceAccountDeleted(c.Client, meta); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controller/elasticsearch.go
+++ b/pkg/controller/elasticsearch.go
@@ -180,6 +180,13 @@ func (c *Controller) ensureElasticsearchNode(elasticsearch *api.Elasticsearch) (
 		return kutil.VerbUnchanged, err
 	}
 
+	if c.EnableRBAC {
+		// Ensure ClusterRoles for statefulsets
+		if err := c.ensureRBACStuff(elasticsearch); err != nil {
+			return kutil.VerbUnchanged, err
+		}
+	}
+
 	vt := kutil.VerbUnchanged
 	topology := elasticsearch.Spec.Topology
 	if topology != nil {

--- a/pkg/controller/rbac.go
+++ b/pkg/controller/rbac.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	core_util "github.com/appscode/kutil/core/v1"
+	api "github.com/kubedb/apimachinery/apis/kubedb/v1alpha1"
+	core "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/reference"
+)
+
+func (c *Controller) deleteServiceAccount(elasticsearch *api.Elasticsearch) error {
+	// Delete existing ServiceAccount
+	if err := c.Client.CoreV1().ServiceAccounts(elasticsearch.Namespace).Delete(elasticsearch.OffshootName(), nil); err != nil {
+		if !kerr.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) createServiceAccount(elasticsearch *api.Elasticsearch) error {
+	ref, rerr := reference.GetReference(clientsetscheme.Scheme, elasticsearch)
+	if rerr != nil {
+		return rerr
+	}
+	// Create new ServiceAccount
+	_, _, err := core_util.CreateOrPatchServiceAccount(
+		c.Client,
+		metav1.ObjectMeta{
+			Name:      elasticsearch.OffshootName(),
+			Namespace: elasticsearch.Namespace,
+		},
+		func(in *core.ServiceAccount) *core.ServiceAccount {
+			core_util.EnsureOwnerReference(&in.ObjectMeta, ref)
+			return in
+		},
+	)
+	return err
+}
+
+func (c *Controller) deleteRoleBinding(elasticsearch *api.Elasticsearch) error {
+	// Delete existing RoleBindings
+	if err := c.Client.RbacV1beta1().RoleBindings(elasticsearch.Namespace).Delete(elasticsearch.OffshootName(), nil); err != nil {
+		if !kerr.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) ensureRBACStuff(elasticsearch *api.Elasticsearch) error {
+	// Create New ServiceAccount
+	if err := c.createServiceAccount(elasticsearch); err != nil {
+		if !kerr.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) deleteRBACStuff(elasticsearch *api.Elasticsearch) error {
+	// Delete ServiceAccount
+	if err := c.deleteServiceAccount(elasticsearch); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -130,6 +130,11 @@ func (c *Controller) ensureStatefulSet(
 		in = upsertCertificate(in, elasticsearch.Spec.CertificateSecret.SecretName, isClient, elasticsearch.Spec.EnableSSL)
 		in = upsertDataVolume(in, elasticsearch.Spec.StorageType, pvcSpec)
 		in = upsertTemporaryVolume(in)
+
+		if c.EnableRBAC {
+			in.Spec.Template.Spec.ServiceAccountName = elasticsearch.OffshootName()
+		}
+
 		in.Spec.UpdateStrategy = elasticsearch.Spec.UpdateStrategy
 
 		return in


### PR DESCRIPTION
…S cluster

ES cluster runs with a dedicated service account instead of default.
Can be handy in case one wants to bind the service account
to a pod security policy (PSP) role binding.